### PR TITLE
Integrate Google API to load terrain from coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -390,9 +390,28 @@
         });
     }
 
+    // *** new code
+    // Google API call to fetch terrain image from coordinates
+    function getGoogleAPITerrainImage(locations, callback) {
+        var lat = locations[0].lat;
+        var lng = locations[0].lng;
+        var format = 'jpg';
+        var zoom = 15;
+        var size = '512x512';
+        var maptype = 'terrain';
+        var url = `http://localhost:3000/google-terrain-image?lat=${lat}&lng=${lng}&zoom=${zoom}&size=${size}&maptype=${maptype}&key=${GOOGLE_API_KEY}`;
+
+        options.terrainImage = url;
+        console.log('New terrainImage options: ', options.terrainImage);
+
+        callback(url);
+    }
+
+    // *** end new code
     var $imageCanvasElem, imageCanvasElemContext;
     var terrainImageData, terrainImageProcessedData;
     function filterTerrainImageAndGenerateHeight() {
+        console.log("In filterTerrainImageAndGenerateHeight()");
         //draw image onto canvas
         //NO NEED TO DO THIS WHEN USING stackBlurImage()
         //imageCanvasElemContext.drawImage($scaledImageObj, 0, 0, terrainImageWidth, terrainImageHeight);
@@ -408,7 +427,8 @@
     }
 
     var $scaledImageObj, $origImageObj;
-    function prepareTerrainImageElements() {
+    function prepareTerrainImageElements(url) {
+        console.log('In prepareTerrainImageElements()');
 
         //create canvas that is same size as terrain res so that one vertex maps to one resized pixel
         $imageCanvasElem = $(document.createElement('canvas'));
@@ -426,7 +446,6 @@
         $scaledImageObj[0].id = 'scaledTerrainImage';
         $scaledImageObj[0].onload = function () {
             //this function is triggered from $origImageObj setting this src
-
             //start filtering and changing heights
             filterTerrainImageAndGenerateHeight();
         };
@@ -435,10 +454,11 @@
 
         //load original terrain image, scale it using canvas, then set scaled image to $scaledImageObj
         $origImageObj = $(new Image());
+        $origImageObj[0].setAttribute('crossOrigin', 'anonymous');
         $origImageObj[0].onload = function () {
             //copy to scaled canvas to scale this image
             imageCanvasElemContext.drawImage($origImageObj[0], 0, 0, TERRAIN_RES, TERRAIN_RES);
-
+            console.log("Drew origImageObj to canvas");
             //get scaled data from canvas and set data for scaledImageObj
             $scaledImageObj[0].src = $imageCanvasElem[0].toDataURL();
         };

--- a/index.html
+++ b/index.html
@@ -1219,10 +1219,8 @@
         //Terrain folder
         terrainFolder = gui.addFolder('Terrain');
         terrainFolder.open();
-
-        /*
-        // *** REMOVE THIS: image select menu
-        control = terrainFolder.add(options, 'terrainImage', terrainImages).name('Test').listen();
+        
+        control = terrainFolder.add(options, 'terrainImage', terrainImages).name('Image').listen();
         changeTerrainImage = function (value) {
 
             loadTerrainImage(value);

--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
     var options = {
         arOn: false,
         arTrackingThreshold: 128,
+
+        // *** add in longitude latitude properties
+        longitudeCoord: '37.9735',
+        latitudeCoord: '122.5311',
+
         terrainImage: terrainImages[Object.keys(terrainImages)[0]],
         terrainMidGreyIsLowest: true,
         terrainPreBlur: terrainImageSettings[Object.keys(terrainImageSettings)[0]].preblur,
@@ -1146,6 +1151,7 @@
 
     var gui;
     var arFolder, terrainFolder, sculptFolder, waterFolder, objectsFolder, renderingFolder, debugFolder;
+    var longlatFolder;
     function setupGui() {
 
         gui = new dat.GUI({width: 300});
@@ -1170,11 +1176,29 @@
             control.onChange(changeTrackingThreshold);
         }
 
+        //Longitude Latitude folder
+        longlatFolder = gui.addFolder('Coordinates');
+        longlatFolder.open();
+
+        control = longlatFolder.add(options, 'longitudeCoord').name('Longitude [-180, 180]').listen();
+        changeLongitude = function (value) {
+            options.longitudeCoord = value;
+        };
+        control.onChange(changeLongitude);
+
+        control = longlatFolder.add(options, 'latitudeCoord').name('Latitude [-90, 90]').listen();
+        changeLatitude = function (value) {
+            options.latitudeCoord = value;
+        };
+        control.onChange(changeLatitude);
+
         //Terrain folder
         terrainFolder = gui.addFolder('Terrain');
         terrainFolder.open();
 
-        control = terrainFolder.add(options, 'terrainImage', terrainImages).name('Image').listen();
+        /*
+        // *** REMOVE THIS: image select menu
+        control = terrainFolder.add(options, 'terrainImage', terrainImages).name('Test').listen();
         changeTerrainImage = function (value) {
 
             loadTerrainImage(value);

--- a/index.html
+++ b/index.html
@@ -131,13 +131,13 @@
         arTrackingThreshold: 128,
 
         // *** add in longitude latitude properties
-        longitudeCoord: '37.9735',
-        latitudeCoord: '122.5311',
+        latitudeCoord: '37.986076',
+        longitudeCoord: '-122.534752',
 
         terrainImage: terrainImages[Object.keys(terrainImages)[0]],
         terrainMidGreyIsLowest: true,
-        terrainPreBlur: terrainImageSettings[Object.keys(terrainImageSettings)[0]].preblur,
-        terrainHeight: terrainImageSettings[Object.keys(terrainImageSettings)[0]].height,
+        terrainPreBlur: 3,
+        terrainHeight: 1,
         sculptSize: 1.0,
         sculptAmount: 0.08,
         sculptClearSculpts: function () {

--- a/index.html
+++ b/index.html
@@ -1610,7 +1610,12 @@
         setupSkulpt();
 
         //setup terrain image
-        prepareTerrainImageElements();
+        //prepareTerrainImageElements();
+        getGoogleAPITerrainImage(
+            [{ lat: options.latitudeCoord,lng: options.longitudeCoord }],
+            function(url) {
+            prepareTerrainImageElements(url);
+        });
         loadTerrainImage(options.terrainImage);
 
         //setup water

--- a/index.html
+++ b/index.html
@@ -56,10 +56,6 @@
 
     <!--load water libraries-->
     <script type="text/javascript" src="js/skunami.min.js"></script>
-
-    <!--load Google Maps JavaScript API
-        TODO: store key safely-->
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCaaXloMwD-My_G_mmVJGIeH347SvbZtho&libraries=places"></script>
     
     <script>
 
@@ -399,7 +395,7 @@
         var zoom = 15;
         var size = '512x512';
         var maptype = 'terrain';
-        var url = `http://localhost:3000/google-terrain-image?lat=${lat}&lng=${lng}&zoom=${zoom}&size=${size}&maptype=${maptype}&key=${GOOGLE_API_KEY}`;
+        var url = `http://localhost:3000/google-terrain-image?lat=${lat}&lng=${lng}&zoom=${zoom}&size=${size}&maptype=${maptype}`;
 
         options.terrainImage = url;
         console.log('New terrainImage options: ', options.terrainImage);

--- a/index.html
+++ b/index.html
@@ -57,6 +57,10 @@
     <!--load water libraries-->
     <script type="text/javascript" src="js/skunami.min.js"></script>
 
+    <!--load Google Maps JavaScript API
+        TODO: store key safely-->
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCaaXloMwD-My_G_mmVJGIeH347SvbZtho&libraries=places"></script>
+    
     <script>
 
     var ARLIB = 'jsartoolkit';

--- a/server.js
+++ b/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const axios = require('axios');
+const cors = require('cors');
+const app = express();
+const port = 3000;
+
+// Enable CORS for Google API
+app.use(cors());
+app.use(function(req, res, next) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Methods", "GET");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+});
+
+app.get('/google-terrain-image', async (req, res) => {
+    const { lat, lng, zoom, size, maptype, key } = req.query;
+    const url = `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=${zoom}&size=${size}&maptype=${maptype}&key=${key}`;
+
+    axios.get(url, {
+        responseType: 'arraybuffer',
+    })
+    .then(response => {
+        console.log('Axios Response: ', response.data);
+        res.set('Content-Type', 'image/jpg');
+        res.status(200).send(response.data);
+    })
+    .catch(error => {
+        console.log('Error fetching terrain image: ', error);
+        res.status(500).send('Error fetching terrain image: ', error);
+    });
+});
+
+
+app.listen(port, () => {
+    console.log(`Proxy server running at http://localhost:${port}`);
+});

--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ const cors = require('cors');
 const app = express();
 const port = 3000;
 
+require('dotenv').config();
+
 // Enable CORS for Google API
 app.use(cors());
 app.use(function(req, res, next) {
@@ -14,7 +16,8 @@ app.use(function(req, res, next) {
 });
 
 app.get('/google-terrain-image', async (req, res) => {
-    const { lat, lng, zoom, size, maptype, key } = req.query;
+    const { lat, lng, zoom, size, maptype } = req.query;
+    const key = process.env.GOOGLE_API_KEY;
     const url = `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=${zoom}&size=${size}&maptype=${maptype}&key=${key}`;
 
     axios.get(url, {


### PR DESCRIPTION
- Created proxy server with Express.js to call the Google Static Maps API. Proxy server needed because certain Maps APIs (static maps included) are server-side only.
- Updated GUI to include text entry forms for coordinate input. Default coordinates set to the Bay Area right now.
- Initial site terrain shows coordinate location at zoom=15 (street view) instead of a pre-determined image


TODO:
- Register changes to latitude/longitude values and update terrain map accordingly